### PR TITLE
✨ Chrome拡張機能へのリンクを別タブで開く

### DIFF
--- a/src/components/ExtensionButton.jsx
+++ b/src/components/ExtensionButton.jsx
@@ -4,6 +4,8 @@ export default function ExtensionButton({ textSize='text-sm' }) {
   return (
     <Link
       href="https://chromewebstore.google.com/detail/laterless-extension/lhickbhpcfdhpljclokijligngkcdmij?hl=ja"
+      target="_blank"
+      rel="noopener noreferrer"
       className={`rounded-full text-center ${textSize} bg-emerald-400 p-2 hover:bg-emerald-200 hover:scale-95`}
     >
       <p>Chrome拡張機能を</p>


### PR DESCRIPTION
## Issue 
https://github.com/yushi32/superior_bookmark_app/issues/45

## 概要
Chrome拡張機能へのリンクを別タブで開くように変更しました。

### 内容
`src/components/ExtensionButton.jsx`ファイル内の`Link`コンポーネントに`target="_blank"`属性と`rel="noopener noreferrer"`属性を追加しました。

## 確認された改善点
アプリからChrome拡張機能への動線の違和感がなくなり、ユーザーエクスペリエンスが向上します。

## コメント
軽微な変更であるため、直接リリースブランチにマージする予定です。